### PR TITLE
Fixes some compile issues on RHEL6 using gcc-4.4.7-4

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <ctype.h>
+#include <stdio.h>
+
 #include "parser.hpp"
 
 int parser::update_lineno(int c)

--- a/smc.cpp
+++ b/smc.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
         compile(stdin, "out.sm");
       } else {
         file = argv[n];
-        compile(fileptr(fopen(argv[n], "rt")), basename(argv[n]) + ".sm");
+        compile(fileptr(fopen(file, "rt")), basename(file) + std::string(".sm"));
       }
     }
 


### PR DESCRIPTION
-Includes stdio.h in parser.cpp to get getc and ungetc declarations.
-Changes smc.cpp to wrap the file suffix in std::string, as this somehow failed to compile on gcc-4.4.7-4
